### PR TITLE
Migrate sample To-Do app to testmuai.com

### DIFF
--- a/Parallel/LT_ToDo_App/tests/test_todo_app.py
+++ b/Parallel/LT_ToDo_App/tests/test_todo_app.py
@@ -9,24 +9,24 @@ from time import sleep
 
 
 def test_lambdatest_todo_app(py):
-    py.visit("https://lambdatest.github.io/sample-todo-app/")
+    py.visit("https://www.testmuai.com/selenium-playground/todo-app/")
     py.maximize_window()
     # py.get uses the CSS Selector, hence we find the CSS Selector of the WebElement using Inspect Tool
     # More information about py.get at https://elsnoman.gitbook.io/pylenium/pylenium-commands/get
-    element_1 = py.get("ul.list-unstyled > li:nth-of-type(1) > [type='checkbox']")
+    element_1 = py.get("input[name='li1']")
     element_1.click()
 
     # Get the instance of the current WebDriver and use the WebDriver commands like they are used in any test automation framework (e.g. PyTest)
     # More information about webdriver at https://elsnoman.gitbook.io/pylenium/pylenium-commands/webdriver
     py.webdriver.find_element(By.NAME, "li2").click()
 
-    title = "Modern To-Do App | LambdaTest"
+    title = "Selenium Grid Online | Run Selenium Test On Cloud"
     assert title == py.title()
 
     sample_text = "Happy Testing at LambdaTest"
 
     # Locate the DOM element using the CSS Selector
-    elem_text_box = py.get("[ng-model='sampleList.sampletodoText']")
+    elem_text_box = py.get("#sampletodotext")
     elem_text_box.type(sample_text)
 
     # The submit method will submit the data but we submit the data by pressing the Add Button
@@ -45,24 +45,24 @@ def test_lambdatest_todo_app(py):
 
 
 def test_lambdatest_todo_app_2(py):
-    py.visit("https://lambdatest.github.io/sample-todo-app/")
+    py.visit("https://www.testmuai.com/selenium-playground/todo-app/")
     py.maximize_window()
     # py.get uses the CSS Selector, hence we find the CSS Selector of the WebElement using Inspect Tool
     # More information about py.get at https://elsnoman.gitbook.io/pylenium/pylenium-commands/get
-    element_2 = py.get("ul.list-unstyled > li:nth-of-type(2) > [type='checkbox']")
+    element_2 = py.get("input[name='li2']")
     element_2.click()
 
     # Get the instance of the current WebDriver and use the WebDriver commands like they are used in any test automation framework (e.g. PyTest)
     # More information about webdriver at https://elsnoman.gitbook.io/pylenium/pylenium-commands/webdriver
     py.webdriver.find_element(By.NAME, "li3").click()
 
-    title = "Modern To-Do App | LambdaTest"
+    title = "Selenium Grid Online | Run Selenium Test On Cloud"
     assert title == py.title()
 
     sample_text = "Happy Testing at LambdaTest"
 
     # Locate the DOM element using the CSS Selector
-    elem_text_box = py.get("[ng-model='sampleList.sampletodoText']")
+    elem_text_box = py.get("#sampletodotext")
     elem_text_box.type(sample_text)
 
     # The submit method will submit the data but we submit the data by pressing the Add Button

--- a/Serial/LT_ToDo_App/tests/test_todo_app.py
+++ b/Serial/LT_ToDo_App/tests/test_todo_app.py
@@ -4,11 +4,11 @@ from selenium.webdriver.common.by import By
 
 
 def test_lambdatest_todo_app(py):
-    py.visit("https://lambdatest.github.io/sample-todo-app/")
+    py.visit("https://www.testmuai.com/selenium-playground/todo-app/")
     py.maximize_window()
     # py.get uses the CSS Selector, hence we find the CSS Selector of the WebElement using Inspect Tool
     # More information about py.get at https://elsnoman.gitbook.io/pylenium/pylenium-commands/get
-    element_1 = py.get("ul.list-unstyled > li:nth-of-type(1) > [type='checkbox']")
+    element_1 = py.get("input[name='li1']")
     element_1.click()
 
     # Get the instance of the current WebDriver and use the WebDriver commands like they are used in any test
@@ -16,13 +16,13 @@ def test_lambdatest_todo_app(py):
     # https://elsnoman.gitbook.io/pylenium/pylenium-commands/webdriver
     py.webdriver.find_element(By.NAME, "li2").click()
 
-    title = "Modern To-Do App | LambdaTest"
+    title = "Selenium Grid Online | Run Selenium Test On Cloud"
     assert title == py.title()
 
     sample_text = "Happy Testing at LambdaTest"
 
     # Locate the DOM element using the CSS Selector
-    elem_text_box = py.get("[ng-model='sampleList.sampletodoText']")
+    elem_text_box = py.get("#sampletodotext")
     elem_text_box.type(sample_text)
 
     # The submit method will submit the data but we submit the data by pressing the Add Button


### PR DESCRIPTION
### What
The LambdaTest sample To-Do app at `https://lambdatest.github.io/sample-todo-app/` has been **deprecated** and replaced by `https://www.testmuai.com/selenium-playground/todo-app/`. This PR points the tests at the new app.

### Why it's more than a URL swap
The new app is a **React** port of the old **AngularJS** app. Stable hooks are preserved — `#sampletodotext`, `#addbutton`, checkbox `name="li1".."liN"`, and added items still get sequential `li6/li7/...` names. But a few things changed, so the affected selectors/assertions were updated and **validated against the live new app**:
- Page `<title>` is now `Selenium Grid Online | Run Selenium Test On Cloud` (was `Modern To-Do App | LambdaTest`).
- Angular `ng-model`/`ng-repeat` attributes are gone → replaced with id/name/class selectors.
- `ul.list-unstyled` class and absolute XPaths like `/html/body/div/div/div/ul/li[N]/span` no longer match the new DOM → replaced with robust relative locators (e.g. `//input[@name='li6']/following-sibling::span`).

### Changes in this repo
```diff
diff --git a/Parallel/LT_ToDo_App/tests/test_todo_app.py b/Parallel/LT_ToDo_App/tests/test_todo_app.py
index 191f34b..59f5e79 100644
--- a/Parallel/LT_ToDo_App/tests/test_todo_app.py
+++ b/Parallel/LT_ToDo_App/tests/test_todo_app.py
@@ -9,24 +9,24 @@ from time import sleep
 
 
 def test_lambdatest_todo_app(py):
-    py.visit("https://lambdatest.github.io/sample-todo-app/")
+    py.visit("https://www.testmuai.com/selenium-playground/todo-app/")
     py.maximize_window()
     # py.get uses the CSS Selector, hence we find the CSS Selector of the WebElement using Inspect Tool
     # More information about py.get at https://elsnoman.gitbook.io/pylenium/pylenium-commands/get
-    element_1 = py.get("ul.list-unstyled > li:nth-of-type(1) > [type='checkbox']")
+    element_1 = py.get("input[name='li1']")
     element_1.click()
 
     # Get the instance of the current WebDriver and use the WebDriver commands like they are used in any test automation framework (e.g. PyTest)
     # More information about webdriver at https://elsnoman.gitbook.io/pylenium/pylenium-commands/webdriver
     py.webdriver.find_element(By.NAME, "li2").click()
 
-    title = "Modern To-Do App | LambdaTest"
+    title = "Selenium Grid Online | Run Selenium Test On Cloud"
     assert title == py.title()
 
     sample_text = "Happy Testing at LambdaTest"
 
     # Locate the DOM element using the CSS Selector
-    elem_text_box = py.get("[ng-model='sampleList.sampletodoText']")
+    elem_text_box = py.get("#sampletodotext")
     elem_text_box.type(sample_text)
 
     # The submit method will submit the data but we submit the data by pressing the Add Button
@@ -45,24 +45,24 @@ def test_lambdatest_todo_app(py):
 
 
 def test_lambdatest_todo_app_2(py):
-    py.visit("https://lambdatest.github.io/sample-todo-app/")
+    py.visit("https://www.testmuai.com/selenium-playground/todo-app/")
     py.maximize_window()
     # py.get uses the CSS Selector, hence we find the CSS Selector of the WebElement using Inspect Tool
     # More information about py.get at https://elsnoman.gitbook.io/pylenium/pylenium-commands/get
-    element_2 = py.get("ul.list-unstyled > li:nth-of-type(2) > [type='checkbox']")
+    element_2 = py.get("input[name='li2']")
     element_2.click()
 
     # Get the instance of the current WebDriver and use the WebDriver commands like they are used in any test automation framework (e.g. PyTest)
     # More information about webdriver at https://elsnoman.gitbook.io/pylenium/pylenium-commands/webdriver
     py.webdriver.find_element(By.NAME, "li3").click()
 
-    title = "Modern To-Do App | LambdaTest"
+    title = "Selenium Grid Online | Run Selenium Test On Cloud"
     assert title == py.title()
 
     sample_text = "Happy Testing at LambdaTest"
 
     # Locate the DOM element using the CSS Selector
-    elem_text_box = py.get("[ng-model='sampleList.sampletodoText']")
+    elem_text_box = py.get("#sampletodotext")
     elem_text_box.type(sample_text)
 
     # The submit method will submit the data but we submit the data by pressing the Add Button
diff --git a/Serial/LT_ToDo_App/tests/test_todo_app.py b/Serial/LT_ToDo_App/tests/test_todo_app.py
index c2d7376..8ef9322 100644
--- a/Serial/LT_ToDo_App/tests/test_todo_app.py
+++ b/Serial/LT_ToDo_App/tests/test_todo_app.py
@@ -4,11 +4,11 @@ from selenium.webdriver.common.by import By
 
 
 def test_lambdatest_todo_app(py):
-    py.visit("https://lambdatest.github.io/sample-todo-app/")
+    py.visit("https://www.testmuai.com/selenium-playground/todo-app/")
     py.maximize_window()
     # py.get uses the CSS Selector, hence we find the CSS Selector of the WebElement using Inspect Tool
     # More information about py.get at https://elsnoman.gitbook.io/pylenium/pylenium-commands/get
-    element_1 = py.get("ul.list-unstyled > li:nth-of-type(1) > [type='checkbox']")
+    element_1 = py.get("input[name='li1']")
     element_1.click()
 
     # Get the instance of the current WebDriver and use the WebDriver commands like they are used in any test
@@ -16,13 +16,13 @@ def test_lambdatest_todo_app(py):
     # https://elsnoman.gitbook.io/pylenium/pylenium-commands/webdriver
     py.webdriver.find_element(By.NAME, "li2").click()
 
-    title = "Modern To-Do App | LambdaTest"
+    title = "Selenium Grid Online | Run Selenium Test On Cloud"
     assert title == py.title()
 
     sample_text = "Happy Testing at LambdaTest"
 
     # Locate the DOM element using the CSS Selector
-    elem_text_box = py.get("[ng-model='sampleList.sampletodoText']")
+    elem_text_box = py.get("#sampletodotext")
     elem_text_box.type(sample_text)
 
     # The submit method will submit the data but we submit the data by pressing the Add Button
```

> Note: the new page's `<title>` looks like it may be inheriting the generic selenium-playground title. If it's later corrected upstream, the title-based assertions here may need revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
